### PR TITLE
rollback call spelled as rollack, corrected spelling

### DIFF
--- a/lib/router/juniper/junos/junos.rb
+++ b/lib/router/juniper/junos/junos.rb
@@ -56,7 +56,7 @@ class Expect4r::J < ::Expect4r::BaseLoginObject
     @matches << [/Exit with uncommitted changes.+\(yes\)/, 'yes']
     output = putline "commit", arg
     if /error: configuration check-out failed/.match(output.join)
-      rollack
+      rollback
       raise SemanticError.new(self.class.to_s, output)
     end
     output


### PR DESCRIPTION
I admire your work here.  I would like to develop similar modules for some of the access equipment I use at work, mainly Calix and Occam equipment.

Please correct me if I am wrong, but I believe I have found a spelling mistake.
