### PR TITLE
Update passwd.rb

### DIFF
--- a/lib/misc/passwd.rb
+++ b/lib/misc/passwd.rb
@@ -9,14 +9,14 @@ begin
     def self.cipher(this, pwd='expect4r')
       c = OpenSSL::Cipher::Cipher.new("aes-256-cbc")
       c.encrypt
-      c.key = key = Digest::SHA1.hexdigest(pwd)
+      c.key = key = Digest::SHA1.hexdigest(pwd)[0..31]
       e = c.update(this)
       e << c.final
     end
     def self.decipher(cipher,pwd='expect4r')
       c = OpenSSL::Cipher::Cipher.new("aes-256-cbc")
       c.decrypt
-      c.key = key = Digest::SHA1.hexdigest(pwd)
+      c.key = key = Digest::SHA1.hexdigest(pwd)[0..31]
       d = c.update(cipher)
       d << c.final
     end


### PR DESCRIPTION
This should fix the ArgumentError issue, see:
r=Expect4r::RShell.new_ssh('192.168.84.216','some_user','some_pass')
ArgumentError: key must be 32 bytes
from /home/user/.rvm/gems/ruby-2.7.1/gems/expect4r-0.0.11/lib/misc/passwd.rb:12:in `key='